### PR TITLE
feat: introduce author username for page name

### DIFF
--- a/content/authors/davidhewwing.yml
+++ b/content/authors/davidhewwing.yml
@@ -1,8 +1,8 @@
 name: David Hew-wing
+username: davidhewwing
 bio: |
   Snorlax is my favorite Pokemon
 avatar: ./avatars/david-hew-wing.jpg
 social:
   - url: https://github.com/DavidHewWing
   - url: https://www.linkedin.com/in/david-hew-wing-8b4381152/
-featured: false

--- a/content/authors/uosc.yml
+++ b/content/authors/uosc.yml
@@ -1,4 +1,5 @@
 name: UOSC
+username: UOSC
 bio: |
   We can post short announcements here!
 avatar: ./avatars/uosc.png

--- a/content/authors/yonglinwang.yml
+++ b/content/authors/yonglinwang.yml
@@ -1,8 +1,8 @@
 name: Yong Lin Wang
+username: yonglinwang
 bio: |
   I love coding <3
 avatar: ./avatars/yonglin-wang.jpg
 social:
   - url: https://github.com/callmekungfu
   - url: https://www.linkedin.com/in/yonglinwang
-featured: false

--- a/content/posts/2020-02-13-keep-grinding-until-someone-notices-you/index.md
+++ b/content/posts/2020-02-13-keep-grinding-until-someone-notices-you/index.md
@@ -1,6 +1,6 @@
 ---
 title: Keep grinding until someone notices you.
-author: David Hew-Wing, UOSC
+author: davidhewwing
 date: 2020-02-13
 hero: ./images/header.jpg
 excerpt: Looking for jobs this summer has been rough for me. I applied to over 200+ SWE Intern positions and am currently 0/4 when giving me an interview. In each case, it seems like I have done well in the white-boarding interviews, with developers actually saying I did an excellent job in the interview.

--- a/content/posts/2020-08-21-how-to-integrate-github-graphql/index.md
+++ b/content/posts/2020-08-21-how-to-integrate-github-graphql/index.md
@@ -1,6 +1,6 @@
 ---
 title: How to use Github's GraphQL API with Express.js
-author: Yong Lin Wang, UOSC
+author: yonglinwang
 date: 2020-08-21
 hero: ./images/header.jpg
 excerpt: GitHub offers a powerful REST based API for developers to get data and integrate

--- a/internals/generators/story/index.js
+++ b/internals/generators/story/index.js
@@ -15,12 +15,12 @@ module.exports = {
     {
       type: 'input',
       name: 'author',
-      message: 'Who will be the author of this story?',
+      message: 'Please provide the author\'s username for this story',
       validate: value => {
         if (/.+/.test(value)) {
           return true;
         }
-        return 'The story date is required';
+        return 'The story author is required';
       },
     },
     {

--- a/src/gatsby/data/data.query.js
+++ b/src/gatsby/data/data.query.js
@@ -66,6 +66,7 @@ module.exports.local = {
           bio
           id
           name
+          username
           featured
           social {
             url

--- a/src/gatsby/node/createPages.js
+++ b/src/gatsby/node/createPages.js
@@ -178,7 +178,7 @@ module.exports = async ({ actions: { createPage }, graphql }, themeOptions) => {
           .split(',')
           .map(a => a.trim().toLowerCase());
 
-        return allAuthors.some(a => a === author.name.toLowerCase());
+        return allAuthors.some(a => a === author.username.toLowerCase());
       });
     } catch (error) {
       throw new Error(`
@@ -228,8 +228,8 @@ module.exports = async ({ actions: { createPage }, graphql }, themeOptions) => {
 
     authors.forEach(author => {
       const articlesTheAuthorHasWritten = articlesThatArentSecret.filter(
-        article =>
-          article.author.toLowerCase().includes(author.name.toLowerCase()),
+        article => 
+          article.author.toLowerCase().includes(author.username.toLowerCase()),
       );
       const path = slugify(author.slug, authorsPath);
 

--- a/src/gatsby/node/onCreateNode.js
+++ b/src/gatsby/node/onCreateNode.js
@@ -48,7 +48,7 @@ module.exports = ({ node, actions, getNode, createNodeId }, themeOptions) => {
   // ///////////////////////////////////////////////////////
 
   if (node.internal.type === `AuthorsYaml`) {
-    const slug = node.slug ? `/${node.slug}` : slugify(node.name);
+    const slug = node.slug ? `/${node.slug}` : slugify(node.username);
 
     const fieldData = {
       ...node,

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -35,6 +35,7 @@ export interface IAuthor {
   authorsPage?: boolean;
   featured?: boolean;
   name: string;
+  username: string;
   slug: string;
   bio: string;
   avatar: {


### PR DESCRIPTION
Currently, pages are being created using the `name` field in authors dir

https://www.uosc.io/stories/authors/David-Hew-wing

This presents some problems if we have two people with the same name...

I'd like to think ahead and included a new username field which will be the updated link.

https://www.uosc.io/stories/authors/davidhewwing

